### PR TITLE
Remove obsolete bearer anonymous code

### DIFF
--- a/simplQ-backend/simplq/src/main/java/me/simplq/controller/advices/AuthenticationFilter.java
+++ b/simplQ-backend/simplq/src/main/java/me/simplq/controller/advices/AuthenticationFilter.java
@@ -60,13 +60,6 @@ public class AuthenticationFilter implements Filter {
       throw new SQAccessDeniedException(UNAUTHORIZED);
     }
 
-    // TODO: Remove after main site is updated to reflect the new auth changes for anonymous device
-    // ID.
-    if ("Bearer anonymous".equals(authHeaderVal)) {
-      loggedInUserInfo.setUserId("anonymous");
-      return;
-    }
-
     if (authHeaderVal.startsWith(BEARER_HEADER_START_WITH)) {
       bearerAuth(authHeaderVal);
       return;

--- a/simplQ-backend/simplq/src/test/java/me/simplq/controller/advices/AuthenticationFilterTest.java
+++ b/simplQ-backend/simplq/src/test/java/me/simplq/controller/advices/AuthenticationFilterTest.java
@@ -1,6 +1,5 @@
 package me.simplq.controller.advices;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -14,7 +13,7 @@ class AuthenticationFilterTest {
   private static final String keyUrl = "https://simplq.us.auth0.com/.well-known/jwks.json";
 
   @ParameterizedTest
-  @ValueSource(strings = {"", "invalid header", "invalid-header", "Bearer invalid-header"})
+  @ValueSource(strings = {"", "invalid header", "invalid-header", "Bearer invalid-header", "Bearer anonymous"})
   void denyBadHeaderValues(String testHeaderValue) throws MalformedURLException {
     var authFilter = new AuthenticationFilter(new LoggedInUserInfo(), keyUrl);
     // Deny bad bearer token
@@ -35,7 +34,5 @@ class AuthenticationFilterTest {
     authFilter.authenticate("Anonymous anonymous-test-id");
     assertEquals("anonymous-test-id", loggedInUserInfo.getUserId());
 
-    // Check backward compatibility, should be removed once frontend is updated on main site
-    assertDoesNotThrow(() -> authFilter.authenticate("Bearer anonymous"));
   }
 }


### PR DESCRIPTION
## Summary
- remove "Bearer anonymous" logic from `AuthenticationFilter`
- update unit tests for new behavior

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687a8b7ed658832698c7f4b0964d33ac