### PR TITLE
Add spinner during notify action

### DIFF
--- a/simplQ-frontend/simplq/src/components/pages/Admin/Token.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/Admin/Token.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import IconButton from '@material-ui/core/IconButton';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import Notifications from '@material-ui/icons/Notifications';
 import NotificationsActiveIcon from '@material-ui/icons/NotificationsActive';
 import NotificationsOffIcon from '@material-ui/icons/NotificationsOffSharp';
@@ -46,9 +47,8 @@ function Token({ token }) {
     if (notifiable === false) {
       return <NotificationsOffIcon fontSize="large" />;
     }
-    // TODO: Add some visual (blinking) while notifyToken is pending
     if (notifyStatus === 'pending') {
-      return <NotificationsOffIcon fontSize="large" />;
+      return <CircularProgress size={24} className={styles['token-spinner']} />;
     }
     if (tokenStatus === 'NOTIFIED') {
       return <NotificationsActiveIcon fontSize="large" className={styles['token-icon-notified']} />;

--- a/simplQ-frontend/simplq/src/components/pages/Admin/admin.module.scss
+++ b/simplQ-frontend/simplq/src/components/pages/Admin/admin.module.scss
@@ -116,6 +116,9 @@
         .token-icon-notified {
           color: green;
         }
+        .token-spinner {
+          color: $primary-color-dark;
+        }
       }
 
       .token-remove {


### PR DESCRIPTION
## Summary
- show a spinner icon while the token notification request is pending
- style the spinner

## Testing
- `npm install` *(fails: node-sass build error)*

------
https://chatgpt.com/codex/tasks/task_e_687a8b7a51188326ba55ed39027c48d4