### PR TITLE
Handle removed tokens in leave queue panel

### DIFF
--- a/simplQ-frontend/simplq/src/components/pages/TokenStatus/LeaveQueue.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/TokenStatus/LeaveQueue.jsx
@@ -14,7 +14,10 @@ export default () => {
     dispatch(deleteToken({ tokenId: token.tokenId, goHome: true }));
   };
 
-  // TODO: The item should be disabled if token is already deteled
+  if (token.tokenStatus === 'REMOVED') {
+    return null;
+  }
+
   return (
     <SidePanelItem
       onClick={onDeleteClick}

--- a/simplQ-frontend/simplq/src/components/pages/TokenStatus/__tests__/LeaveQueue.test.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/TokenStatus/__tests__/LeaveQueue.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { rootReducer } from 'store';
+
+import LeaveQueue from '../LeaveQueue';
+
+jest.mock('store/asyncActions', () => ({
+  useDeleteToken: () => jest.fn(),
+}));
+
+const renderWithState = (state) => {
+  const store = configureStore({ reducer: rootReducer, preloadedState: state });
+  return render(
+    <Provider store={store}>
+      <LeaveQueue />
+    </Provider>
+  );
+};
+
+test('does not render leave queue item when token is removed', () => {
+  renderWithState({ token: { tokenStatus: 'REMOVED' } });
+  expect(screen.queryByText(/leave queue/i)).toBeNull();
+});


### PR DESCRIPTION
## Summary
- hide Leave Queue side panel item when token was removed
- test that LeaveQueue does not render when token.status is REMOVED

## Testing
- `npm install` *(fails: node-sass build error)*

------
https://chatgpt.com/codex/tasks/task_e_687a8b7661a8832685eaa04db1e85542