### PR TITLE
Add root env example and load env in build scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_URL=jdbc:postgresql://localhost:5432/simplq
+DB_USERNAME=admin
+DB_PASSWORD=password
+TOKEN_URL=https://simplq.me/token/
+BASE_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ simplQ-UPeU es una solución completa de código abierto para administrar colas 
 
 ## Requisitos para desarrollo local
 
+Antes de iniciar, copia el archivo `.env.example` a `.env` en la raíz del proyecto y completa los valores correspondientes.
+
 ### Backend
 
 1. Java 11 y Maven instalados.

--- a/simplQ-backend/scripts/run-jar.sh
+++ b/simplQ-backend/scripts/run-jar.sh
@@ -1,1 +1,4 @@
+set -a
+[ -f /deployed/.env ] && . /deployed/.env
+set +a
 systemctl restart sqbackenddev

--- a/simplQ-frontend/simplq/gulpfile.js
+++ b/simplQ-frontend/simplq/gulpfile.js
@@ -3,7 +3,8 @@ const pumpify = require('pumpify');
 const { Readable } = require('stream');
 const { createWriteStream } = require('fs');
 
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '../..', '.env') });
 
 const defaultTask = (cb) => {
   const code = `export const baseURL = "${process.env.BASE_URL}"`;


### PR DESCRIPTION
## Summary
- add unified `.env.example` with backend and frontend vars
- load root `.env` from frontend gulpfile
- export env vars in backend restart script
- document env file setup in README

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*
- `npm install` *(fails: node-sass build error due to missing Python 2)*

------
https://chatgpt.com/codex/tasks/task_e_687abfdb3d7c8326bb5f1c0df3c7ae78