### PR TITLE
Remove obsolete frontend env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ simplQ-UPeU es una solución completa de código abierto para administrar colas 
 ## Requisitos para desarrollo local
 
 Antes de iniciar, copia el archivo `.env.example` a `.env` en la raíz del proyecto y completa los valores correspondientes.
+Este mismo archivo se utiliza para configurar tanto el backend como el frontend.
 
 ### Backend
 

--- a/docs/INSTALACION_SERVIDOR.md
+++ b/docs/INSTALACION_SERVIDOR.md
@@ -31,10 +31,10 @@ export DB_PASSWORD=password
 export DB_URL=jdbc:postgresql://localhost:5432/simplq
 ```
 
-Para el frontend copia el archivo `.env.example` y ajusta la URL del backend:
+Para el frontend utiliza el archivo `.env` en la raíz del proyecto y ajusta la variable `BASE_URL` si es necesario:
 
 ```bash
-cp simplQ-frontend/simplq/.env.example simplQ-frontend/simplq/.env
+cp .env.example .env
 # Edita BASE_URL si es necesario
 ```
 

--- a/simplQ-frontend/README.md
+++ b/simplQ-frontend/README.md
@@ -12,7 +12,7 @@ Sigue estos pasos la primera vez que ejecutes el proyecto.
 
 1. Instala Node 12.x siguiendo las instrucciones [aqui](https://github.com/nodesource/distributions/blob/master/README.md#debinstall).
 2. Clona este proyecto.
-3. Copia `.env.example` a `.env` dentro de la carpeta `simplq` y personalízalo si es necesario.
+3. Copia el archivo `.env.example` ubicado en la raíz del proyecto a `.env` (en la misma raíz) y personalízalo si es necesario.
 4. Entra en la carpeta `simplq` e instala las dependencias:
 
 ```

--- a/simplQ-frontend/simplq/.env.example
+++ b/simplQ-frontend/simplq/.env.example
@@ -1,1 +1,0 @@
-BASE_URL="https://devbackend.simplq.me/v1"


### PR DESCRIPTION
## Summary
- remove unused `simplQ-frontend/simplq/.env.example`
- update docs to copy env file from repo root
- clarify that single `.env` is shared for backend and frontend

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac51e3ad48326af5cd6abf3750424