### PR TITLE
Minor improvements and dependency tweaks

### DIFF
--- a/simplQ-backend/simplq/src/main/java/me/simplq/controller/QueueController.java
+++ b/simplQ-backend/simplq/src/main/java/me/simplq/controller/QueueController.java
@@ -12,6 +12,7 @@ import me.simplq.controller.model.queue.QueueDetailsResponse;
 import me.simplq.controller.model.queue.QueueEventsResponse;
 import me.simplq.controller.model.queue.QueueStatusResponse;
 import me.simplq.controller.model.queue.UpdateQueueStatusResponse;
+import me.simplq.exceptions.SQInvalidRequestException;
 import me.simplq.service.QueueService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -77,7 +78,7 @@ public class QueueController {
     } else if (queueName != null) {
       return ResponseEntity.ok(queueService.getQueueStatusByName(queueName));
     } else {
-      return ResponseEntity.badRequest().build(); // Todo Give reason
+      throw SQInvalidRequestException.queueIdentifierRequired();
     }
   }
 

--- a/simplQ-backend/simplq/src/main/java/me/simplq/exceptions/SQInvalidRequestException.java
+++ b/simplQ-backend/simplq/src/main/java/me/simplq/exceptions/SQInvalidRequestException.java
@@ -16,7 +16,8 @@ public class SQInvalidRequestException extends SQException {
     QUEUE_DELETE_NOT_ALLOWED,
     QUEUE_IS_FULL,
     ONLY_OWNER_CAN_CREATE_TOKEN,
-    TOKEN_ALREADY_WAITING;
+    TOKEN_ALREADY_WAITING,
+    QUEUE_IDENTIFIER_REQUIRED;
   }
 
   static {
@@ -33,6 +34,9 @@ public class SQInvalidRequestException extends SQException {
         ReasonCode.ONLY_OWNER_CAN_CREATE_TOKEN,
         "Only queue owner can create tokens for this queue");
     registerMessage(ReasonCode.TOKEN_ALREADY_WAITING, "Sorry, you are already present in the queue.");
+    registerMessage(
+        ReasonCode.QUEUE_IDENTIFIER_REQUIRED,
+        "Either queueId or queueName parameter must be provided");
   }
 
   private final ReasonCode reasonCode;
@@ -83,6 +87,10 @@ public class SQInvalidRequestException extends SQException {
 
   public static SQInvalidRequestException tokenAlreadyWaiting() {
     return new SQInvalidRequestException(ReasonCode.TOKEN_ALREADY_WAITING);
+  }
+
+  public static SQInvalidRequestException queueIdentifierRequired() {
+    return new SQInvalidRequestException(ReasonCode.QUEUE_IDENTIFIER_REQUIRED);
   }
 
   public ReasonCode getReasonCode() {

--- a/simplQ-backend/simplq/src/main/java/me/simplq/service/notification/TexLocalSmsChannel.java
+++ b/simplQ-backend/simplq/src/main/java/me/simplq/service/notification/TexLocalSmsChannel.java
@@ -43,7 +43,6 @@ public class TexLocalSmsChannel implements NotificationChannel {
       }
       rd.close();
     } catch (Exception e) {
-      // TODO Move to exception framework
       throw new SQInternalServerException("Error sending SMS" + e.getMessage(), e);
     }
   }

--- a/simplQ-frontend/README.md
+++ b/simplQ-frontend/README.md
@@ -10,7 +10,7 @@
 
 Sigue estos pasos la primera vez que ejecutes el proyecto.
 
-1. Instala Node 12.x siguiendo las instrucciones [aqui](https://github.com/nodesource/distributions/blob/master/README.md#debinstall).
+1. Instala Node 18.x siguiendo las instrucciones [aqui](https://github.com/nodesource/distributions/blob/master/README.md#debinstall).
 2. Clona este proyecto.
 3. Copia el archivo `.env.example` ubicado en la raíz del proyecto a `.env` (en la misma raíz) y personalízalo si es necesario.
 4. Entra en la carpeta `simplq` e instala las dependencias:

--- a/simplQ-frontend/simplq/Dockerfile
+++ b/simplQ-frontend/simplq/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.16-alpine AS build
+FROM node:18-alpine AS build
 
 ARG BASE_URL="https://devbackend.simplq.me/v1"
 


### PR DESCRIPTION
## Summary
- improve error handling for queue status request
- remove obsolete TODO comment
- document Node 18 requirement
- upgrade build container image to Node 18

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*
- `npm test --silent --ci` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b67eb9cb08326883869eb6e1154bf