### PR TITLE
Clean docs and restrict queue creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DB_URL=jdbc:postgresql://localhost:5432/simplq
 DB_USERNAME=simplq
 DB_PASSWORD=simplq
-TOKEN_URL=https://simplq.me/token/
+TOKEN_URL=http://localhost/token/
 BASE_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ simplQ-UPeU es una solución completa de código abierto para administrar colas 
    - Consultar el estado de un turno o eliminarlo de la cola.
 
 3. **Notificaciones**
-  - El sistema puede enviar notificaciones mediante correo electrónico (Amazon SES), SMS (canal simulado o servicios externos) y notificaciones push usando Firebase.
+  - El sistema puede enviar notificaciones mediante correo electrónico, SMS y notificaciones push.
 
 ## Descargar el proyecto
 
@@ -74,7 +74,6 @@ npm start
 ## Instalación
 
 - [Instalación en servidor](docs/INSTALACION_SERVIDOR.md)
-- [Despliegue en AWS](docs/INSTALACION_AWS.md)
 
 Cada módulo incluye un `README.md` con detalles adicionales. Para conocer la estructura de código del frontend consulta `simplQ-frontend/simplq/readme.md` y para el backend `simplQ-backend/README.md`.
 

--- a/simplQ-backend/README.md
+++ b/simplQ-backend/README.md
@@ -1,12 +1,10 @@
 # SimplQ Backend
 
-[![Build Status](https://travis-ci.org/SimplQ/simplQ-backend.svg?branch=master)](https://travis-ci.org/SimplQ/simplQ-backend)
-
-[SimplQ](https://simplq.me) is a completely web based queue management solution that anyone can use to create instant queues. 
+SimplQ Backend es la API que gestiona las colas y los turnos.
 
 ## Environment Setup Instructions
 
-El proyecto está escrito en Java y se despliega en AWS. Sigue estos pasos la primera vez que ejecutes el proyecto.
+El proyecto está escrito en Java. Sigue estos pasos la primera vez que ejecutes el proyecto.
 
 1. Instala Java 11 y Maven.
 2. Clona este proyecto.
@@ -33,9 +31,7 @@ Seguimos las [Guías de estilo de Java de Google](https://github.com/google/styl
 
 ### Pruebas locales
 
-Prueba las APIs con Postman: hay una colección de prueba disponible [aquí](https://www.getpostman.com/collections/252a096a86fc550fb5fb).
-
-Ejecuta las pruebas de integración:
+Para ejecutar las pruebas de integración:
 
 ```
 mvn test

--- a/simplQ-backend/simplq/src/main/java/me/simplq/service/message/Message.java
+++ b/simplQ-backend/simplq/src/main/java/me/simplq/service/message/Message.java
@@ -2,10 +2,8 @@ package me.simplq.service.message;
 
 public interface Message {
   String FOOTER =
-      "<p>Thanks for using simplq.me, a free and open source queue management software.</p>"
-          + "<p>Regards,</p>"
-          + "<p>Team SimplQ</p>"
-          + "<p>https://www.simplq.me/</p>";
+      "<p>Gracias por utilizar este sistema.</p>"
+          + "<p>Equipo de soporte</p>";
 
   String subject();
 

--- a/simplQ-backend/simplq/src/main/java/me/simplq/service/notification/SesEmailNotificationChannel.java
+++ b/simplQ-backend/simplq/src/main/java/me/simplq/service/notification/SesEmailNotificationChannel.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.services.ses.model.SesException;
 @Slf4j
 public class SesEmailNotificationChannel implements NotificationChannel {
   private final SesClient client = SesClient.builder().region(Region.US_WEST_2).build();
-  private static final String FROM_EMAIL = "notifications@simplq.me";
+  private static final String FROM_EMAIL = "noreply@example.com";
 
   @Override
   public void notify(Token token, me.simplq.service.message.Message message) {
@@ -76,8 +76,7 @@ public class SesEmailNotificationChannel implements NotificationChannel {
       // Add the multipart/alternative part to the message
       msg.addBodyPart(wrap);
 
-      System.out.println(
-          "Attempting to send an email through Amazon SES " + "using the AWS SDK for Java...");
+      System.out.println("Enviando correo electrónico...");
 
       ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
       email.writeTo(outputStream);

--- a/simplQ-backend/simplq/src/main/resources/application.properties
+++ b/simplQ-backend/simplq/src/main/resources/application.properties
@@ -10,4 +10,4 @@ spring.datasource.password=${DB_PASSWORD:simplq}
 spring.liquibase.enabled=false
 app.notifications.enabled=true
 
-token.url = ${TOKEN_URL:https://simplq.me/token/}
+token.url = ${TOKEN_URL:http://localhost/token/}

--- a/simplQ-backend/simplq/src/test/java/me/simplq/service/message/MessagesManagerTest.java
+++ b/simplQ-backend/simplq/src/test/java/me/simplq/service/message/MessagesManagerTest.java
@@ -21,9 +21,8 @@ class MessagesManagerTest {
           + " 42.</p><p>You can check your live status by visiting"
           + " http://token-test-url/test-token-id</p><p><b>Please wait to be notified before you"
           + " visit the location. Stay away from crowds and have a delightful"
-          + " experience.</b></p><p>Thanks for using simplq.me, a free and open source queue"
-          + " management software.</p><p>Regards,</p><p>Team SimplQ</p>"
-          + "<p>https://www.simplq.me/</p>";
+          + " experience.</b></p><p>Gracias por utilizar este sistema.</p>"
+          + "<p>Equipo de soporte</p>";
 
   private static final String END_MESSAGE_SUBJECT_EXPECTED =
       "test-queue: Hooray! your wait is finally over.";
@@ -31,10 +30,8 @@ class MessagesManagerTest {
       "<p>Hi test-user-name,</p>"
           + "<p>You have been notified by the queue admin. Your turn will be up soon.</p>"
           + "<p><b>Please proceed to the location now.</b></p>"
-          + "<p>Thanks for using simplq.me, a free and open source queue management software.</p>"
-          + "<p>Regards,</p>"
-          + "<p>Team SimplQ</p>"
-          + "<p>https://www.simplq.me/</p>";
+          + "<p>Gracias por utilizar este sistema.</p>"
+          + "<p>Equipo de soporte</p>";
 
   @Autowired private MessagesManager manager;
 

--- a/simplQ-backend/simplq/src/test/resources/application.properties
+++ b/simplQ-backend/simplq/src/test/resources/application.properties
@@ -2,5 +2,5 @@ spring.datasource.url=jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1;
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driverClassName=org.h2.Driver
-token.url=${TOKEN_URL:https://simplq.me/token/}
+token.url=${TOKEN_URL:http://localhost/token/}
 app.notifications.enabled=false

--- a/simplQ-frontend/CONTRIBUTING.md
+++ b/simplQ-frontend/CONTRIBUTING.md
@@ -7,8 +7,4 @@ Feel free to fork and improve.Here are a few things to note before you head on:
 
 -  Go through the [readme](/simplq/readme.md) file for details on file structure and tools used.
 
--  The frontend is being revamped heavily right and we're implementing this new [design](https://xd.adobe.com/view/ad1db074-03bf-45b1-537b-98d9d524ec82-db2c/grid) 
-
--   The assets (icons, images) we're using are available for download. 
-
--  You can see the frontend live [here](https://simplq.me/).
+The frontend está en constante mejora.

--- a/simplQ-frontend/README.md
+++ b/simplQ-frontend/README.md
@@ -1,10 +1,6 @@
 # SimplQ
 
-![Build and Deploy](https://img.shields.io/github/issues/SimplQ/simplQ-frontend)
-![Build and Deploy](https://img.shields.io/github/license/SimplQ/simplQ-frontend)
-![Gitter](https://img.shields.io/gitter/room/SimplQ/community)
-
-[SimplQ](https://simplq.me) es una solución de gestión de colas totalmente web que cualquiera puede usar para crear colas virtuales al instante. Visítanos en [ProductHunt](https://www.producthunt.com/posts/simplq) para saber más y apoyarnos.
+[SimplQ](https://github.com/UPeU-CRAI/simplQ-UPeU) es una solución de gestión de colas de código abierto construida con React.
 
 ### Instrucciones para configurar el entorno de desarrollo
 
@@ -40,11 +36,8 @@ Siéntete libre de hacer un fork y mejorar; envía un pull request. Busca issues
 
 Hay muchas características en planificación. Si deseas contribuir, primero comenta los cambios que quieras realizar mediante el issue tracker.
 
-En el archivo [readme](/simplq/readme.md) se detallan la estructura de archivos y las herramientas utilizadas. Por favor revísalo primero. Este es el [diseño](https://xd.adobe.com/view/ad1db074-03bf-45b1-537b-98d9d524ec82-db2c/grid) que hemos implementado y aquí puedes descargar los recursos (iconos, imágenes). El sitio web está disponible [aquí](https://simplq.me/).
-
-Hoja de ruta de implementación: https://github.com/SimplQ/simplQ-frontend/issues/207
-
+En el archivo [readme](/simplq/readme.md) se detallan la estructura de archivos y las herramientas utilizadas.
 
 # Despliegue
 
-Los cambios en la rama master se despliegan automáticamente en [dev.simplq.me](https://dev.simplq.me/). Periódicamente revisamos esa versión y la promovemos a [simplq.me](https://simplq.me).
+La aplicación puede desplegarse en cualquier servidor que sirva archivos estáticos.

--- a/simplQ-frontend/simplq/Dockerfile
+++ b/simplQ-frontend/simplq/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14.16-alpine AS build
 
-ARG BASE_URL="https://devbackend.simplq.me/v1"
+ARG BASE_URL="http://localhost:8080/v1"
 
 RUN echo ${BASE_URL}
 

--- a/simplQ-frontend/simplq/public/manifest.json
+++ b/simplQ-frontend/simplq/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "SimplQ",
-  "name": "SimplQ - A long overdue alternative to physical queues",
+  "name": "SimplQ Queue Management",
   "icons": [
     {
       "src": "/images/Simple-Q-144x144.png",

--- a/simplQ-frontend/simplq/src/components/common/CreateJoinForm/CreateJoinForm.jsx
+++ b/simplQ-frontend/simplq/src/components/common/CreateJoinForm/CreateJoinForm.jsx
@@ -2,9 +2,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router';
 import { handleEnterPress } from 'utils/eventHandling';
 import { isQueueNameValid } from 'utils/textOperations';
-import { useCreateQueue } from 'store/asyncActions';
-import { useDispatch } from 'react-redux';
-import LoadingStatus from 'components/common/Loading';
+
 import styles from './CreateJoinForm.module.scss';
 import InputField from '../InputField';
 import StandardButton from '../Button';
@@ -13,19 +11,12 @@ const CreateJoinForm = (props) => {
   const [textFieldValue, setTextFieldValue] = useState(props.defaultTextFieldValue);
   const [invalidMsg, setInvalidMsg] = useState('');
   const history = useHistory();
-  const createQueue = useCreateQueue();
-  const dispatch = useDispatch();
 
-  const handleCreateClick = () => {
-    if (!textFieldValue) {
-      setInvalidMsg('Line name is required');
-      return;
-    }
-    dispatch(createQueue({ queueName: textFieldValue }));
-  };
+
+
 
   const handleJoinClick = () => {
-    if (!textFieldValue) setInvalidMsg('Line name is required');
+    if (!textFieldValue) setInvalidMsg('Queue name is required');
     else {
       history.push(`/j/${textFieldValue}`);
     }
@@ -52,24 +43,19 @@ const CreateJoinForm = (props) => {
           placeholder="Line Name"
           value={textFieldValue || ''}
           onChange={handleTextFieldChange}
-          onKeyPress={(e) => handleEnterPress(e, handleCreateClick)}
+          onKeyPress={(e) => handleEnterPress(e, handleJoinClick)}
           error={invalidMsg.length > 0}
           helperText={invalidMsg}
           autoFocus
         />
       </div>
       <div className={styles['button-group']}>
-        <LoadingStatus dependsOn="createQueue">
-          <div>
-            <StandardButton onClick={handleCreateClick}>Create Line</StandardButton>
-          </div>
-          <div>
-            <StandardButton onClick={handleJoinClick}>Know Your Position</StandardButton>
-          </div>
-          <div>
-            <StandardButton onClick={handleScanAnyQR}>Scan Any QR</StandardButton>
-          </div>
-        </LoadingStatus>
+        <div>
+          <StandardButton onClick={handleJoinClick}>Join Queue</StandardButton>
+        </div>
+        <div>
+          <StandardButton onClick={handleScanAnyQR}>Scan QR</StandardButton>
+        </div>
       </div>
     </div>
   );

--- a/simplQ-frontend/simplq/src/components/common/Footer/Footer.jsx
+++ b/simplQ-frontend/simplq/src/components/common/Footer/Footer.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import FacebookIcon from '@material-ui/icons/Facebook';
-import YouTubeIcon from '@material-ui/icons/YouTube';
-import GitHubIcon from '@material-ui/icons/GitHub';
-import MailIcon from '@material-ui/icons/Mail';
 import styles from './Footer.module.scss';
 import ClickableLogo from '../ClickableLogo';
-import StandardButton from '../Button';
 
 const dayOfWeek = () =>
   typeof Intl === 'object' && typeof Intl.DateTimeFormat === 'function'
@@ -19,11 +14,6 @@ export default () => (
       <div className={styles['card-body']}>
         <div className={styles['description-content-container']}>
           <b>
-            SimplQ is a free queue management system that anyone can use to create
-            instant online queues. Our queue management app is open source and 
-            aims to make crowd maangement easy for businesses and personal use.
-            <br />
-            <br />
             <a href="/privacy">Privacy Policy</a>
             <br />
             <a href="/privacy#terms-of-service">Terms of Service</a>
@@ -31,77 +21,6 @@ export default () => (
             <br />
             <i>{`Enjoy the rest of your ${dayOfWeek()}!`}</i>
           </b>
-        </div>
-      </div>
-    </div>
-
-    <div className={styles['card']}>
-      <h1>
-        Open source
-        <br />
-        <a
-          className="github-button"
-          href="https://github.com/simplQ/simplQ-frontend"
-          data-color-scheme="no-preference: light; light: light; dark: dark;"
-          data-show-count="true"
-          aria-label="Star simplQ/simplQ-frontend on GitHub"
-        >
-          Star
-        </a>
-      </h1>
-      <div className={styles['card-body']}>
-        <div className={styles['open-source-content-container']}>
-          <p>
-            <b>
-              <span>SimplQ </span>
-              is open source. Be part of the
-              <span> SimplQ </span>
-              community.
-            </b>
-          </p>
-
-          <StandardButton
-            icon={<GitHubIcon />}
-            onClick={() => {
-              window.location.href = 'https://github.com/SimplQ/simplQ-frontend';
-            }}
-          >
-            Contribute on Github
-          </StandardButton>
-        </div>
-      </div>
-    </div>
-
-    <div className={styles['card']}>
-      <h1>Keep in touch</h1>
-      <div className={styles['card-body']}>
-        <div className={styles['list-container']}>
-          <div className={styles['list-container-item']}>
-            <a href="https://github.com/SimplQ/simplQ-frontend">
-              <GitHubIcon fontSize="large" />
-            </a>
-          </div>
-          <div className={styles['list-container-item']}>
-            <a href="https://medium.com/@raimazach/virtualizing-queues-a-long-overdue-alternative-to-physical-queues-bfdc4b51070f">
-              <img alt="medium-link" src="/images/ICON-MEDIUM.svg" />
-            </a>
-          </div>
-          <div className={styles['list-container-item']}>
-            <a href="https://www.youtube.com/channel/UCAb9PSXvrGZ4vvSneK1Nrow">
-              {/* Youtube Icon was looking smaller that others, setting height/width manually via css to match other icons */}
-              <YouTubeIcon className={styles['youtube-icon']} fontSize="large" />
-            </a>
-          </div>
-          <div className={styles['list-container-item']}>
-            <a href="https://www.facebook.com/simplq/">
-              <FacebookIcon fontSize="large" />
-            </a>
-          </div>
-          <div className={styles['list-container-item']}>
-            <a href="mailto:contact@simplq.me">
-              <MailIcon fontSize="large" />
-            </a>
-          </div>
         </div>
       </div>
     </div>

--- a/simplQ-frontend/simplq/src/components/pages/Home/HomePage.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/Home/HomePage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { smoothScrollToHomePageTop } from 'utils/scrollingOperations';
-import { BenefitsInfo, HowToCreate, HowToJoin, ExtraInfo, Pricing } from './StaticInfos';
+import { BenefitsInfo, HowToCreate, HowToJoin, ExtraInfo } from './StaticInfos';
 import LandingPage from './LandingPage';
 
 const HomePage = () => {
@@ -13,7 +13,6 @@ const HomePage = () => {
       <HowToCreate />
       <HowToJoin />
       <ExtraInfo />
-      <Pricing />
     </>
   );
 };

--- a/simplQ-frontend/simplq/src/components/pages/Home/LandingPage.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/Home/LandingPage.jsx
@@ -6,7 +6,7 @@ import styles from './Home.module.scss';
 import MyQueues from './MyQueues';
 
 export default () => {
-  let subtitle = 'Give Your Customers a Delightful Waiting Experience.';
+  let subtitle = 'Bienvenido';
   const { user, isAuthenticated } = useAuth0();
   if (isAuthenticated) {
     subtitle = `Hi ${user.name}, welcome back!`;
@@ -17,10 +17,7 @@ export default () => {
       <div data-aos="zoom-in">
         <Header className={styles['main-header']}>SimplQ</Header>
         <p className={styles.subtitle}>{subtitle}</p>
-        <p className={styles.description}>
-          Web based free queue management software to let your customers feel more relaxed and
-          delighted.
-        </p>
+        <p className={styles.description}>Gestión sencilla de colas virtuales.</p>
       </div>
       <MyQueues />
       <QueueForm />

--- a/simplQ-frontend/simplq/src/components/pages/Home/MyQueues.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/Home/MyQueues.jsx
@@ -23,8 +23,8 @@ export default () => {
     <div className={styles['my-queue']}>
       <p>
         {queues.length === 0
-          ? "Looks like you don't have any active queues. Start by creating one..."
-          : 'What would you like to do today? Here are your active queues:'}
+          ? 'No hay colas activas.'
+          : 'Estas son tus colas activas:'}
       </p>
       {queues.map((queue) => {
         const handler = () => history.push(`/queue/${queue.queueId}`);

--- a/simplQ-frontend/simplq/src/components/pages/Home/StaticInfos.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/Home/StaticInfos.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import StandardButton from 'components/common/Button';
-import { smoothScrollToHomePageTop } from 'utils/scrollingOperations';
+
 import styles from './Home.module.scss';
 
 export const BenefitsInfo = () => (
@@ -122,12 +121,9 @@ export const ExtraInfo = () => (
   <div className={`${styles['section']} ${styles['extra-info']}`}>
     <div className={`${styles['container']} ${styles['extra-container']}`}>
       <div className={styles['card']}>
-        <img src="/images/free.svg" alt="free" />
-        <p className={styles['brief-description']}>Always free</p>
-        <p className={styles['detailed-description']}>
-          We are a team of enthusiastic developers who want to give back to society and do not
-          prioritize monetary gains.
-        </p>
+        <img src="/images/free.svg" alt="open" />
+        <p className={styles['brief-description']}>Código abierto</p>
+        <p className={styles['detailed-description']}>El proyecto está disponible de forma gratuita.</p>
       </div>
       <div className={styles['card']}>
         <img src="/images/secure.svg" alt="secure" />
@@ -147,50 +143,4 @@ export const ExtraInfo = () => (
   </div>
 );
 
-export const Pricing = () => (
-  <div data-aos="fade-up" className={`${styles['section']} ${styles['get-started']}`}>
-    <h2 data-aos="zoom-in">Pricing - Plans for every use case</h2>
-    <div className={styles['container']}>
-      <div className={styles['price-card']}>
-        <h1>Free</h1>
-        <p className={styles['subtitle']}>Basic for small businesses.</p>
-        <li>
-          <ul>Unlimited Queues</ul>
-          <ul>20,000 tokens per month.</ul>
-        </li>
-        <p className={styles['amount']}>$0</p>
-        <StandardButton onClick={smoothScrollToHomePageTop}>Start for free</StandardButton>
-      </div>
-      <div className={styles['price-card']}>
-        <h1>Business</h1>
-        <p className={styles['subtitle']}>For bigger companies.</p>
-        <li>
-          <ul>Everything in the free plan.</ul>
-          <ul>Unlimited tokens per month.</ul>
-          <ul>Custom subdomains.</ul>
-          <ul>Multi-user support.</ul>
-          <ul>Priority Customer Support.</ul>
-        </li>
-        <p className={styles['amount']}>$8.99/mo</p>
-        <StandardButton onClick={smoothScrollToHomePageTop}>Upgrade</StandardButton>
-      </div>
-      <div className={styles['price-card']}>
-        <h1>Enterprise</h1>
-        <p className={styles['subtitle']}>Best for unique requirements that need to scale.</p>
-        <li>
-          <ul>Everything in the business plan.</ul>
-          <ul>In-house installation support.</ul>
-          <ul>Custom features, integrations, branding.</ul>
-        </li>
-        <StandardButton
-          onClick={() => {
-            window.location = 'https://kss9gyhvcy3.typeform.com/to/kHJHPLEr';
-          }}
-        >
-          Contact Sales
-        </StandardButton>
-      </div>
-    </div>
-    <p>* No credit card required till you upgrade.</p>
-  </div>
-);
+export const Pricing = () => null;

--- a/simplQ-frontend/simplq/src/components/pages/PageNotFound/index.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/PageNotFound/index.jsx
@@ -11,10 +11,7 @@ function PageNotFound(props) {
         <div className={styles.main}>
           <div className={styles.text}>
             <h1 className={styles.center}>Oops 404!</h1>
-            <p>
-              A queue with that name doesn&apos;t exist, please enter a valid queue name or create
-              one
-            </p>
+            <p>A queue with that name doesn&apos;t exist, please enter a valid queue name.</p>
             <CreateJoinForm defaultTextFieldValue={props.match.params.queueName} />
           </div>
         </div>

--- a/simplQ-frontend/simplq/src/components/pages/TermsOfService/index.jsx
+++ b/simplQ-frontend/simplq/src/components/pages/TermsOfService/index.jsx
@@ -13,8 +13,7 @@ function TermsOfService() {
         <p>
           Your privacy is important to us. It is SimplQ&apos;s policy to respect your privacy
           regarding any information we may collect from you across our website,&nbsp;
-          <a href="https://simplq.me">https://simplq.me</a>
-          <span>, and other sites we own and operate.</span>
+          nuestro sitio web y otras páginas que operamos.
         </p>
         <p>
           We only ask for personal information when we truly need it to provide a service to you. We
@@ -49,10 +48,9 @@ function TermsOfService() {
         <h2 id="terms-of-service">SimplQ Terms of Service</h2>
         <h3>1. Terms</h3>
         <p>
-          By accessing the website at&nbsp;
-          <a href="https://simplq.me">https://simplq.me</a>
+          By accessing nuestro sitio web,
           <span>
-            , you are agreeing to be bound by these terms of service, all applicable laws and
+            aceptas cumplir con estos términos de servicio, todas las leyes aplicables y
             regulations, and agree that you are responsible for compliance with any applicable local
             laws. If you do not agree with any of these terms, you are prohibited from using or
             accessing this site. The materials contained in this website are protected by applicable

--- a/simplQ-frontend/simplq/src/index.jsx
+++ b/simplQ-frontend/simplq/src/index.jsx
@@ -29,10 +29,10 @@ const theme = createTheme({
 
 ReactDOM.render(
   <Auth0Provider
-    domain="simplq.us.auth0.com"
-    clientId="9BAywifjAy6n0sx8WbuQubMGGjofpwd6"
+    domain="your-auth-domain"
+    clientId="your-client-id"
     redirectUri={window.location.origin}
-    audience="https://devbackend.simplq.me/v1"
+    audience="http://localhost:8080/v1"
     scope="read:current_user update:current_user_metadata"
     cacheLocation="localstorage"
     useRefreshTokens


### PR DESCRIPTION
## Summary
- remove references to third‑party services in docs and code
- simplify Terms of Service wording
- adjust backend notification footer and email settings
- hide queue creation for regular users
- clean landing page and static info

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b6b4c972c8326b6834bae53753eb6