### PR TITLE
Update Node.js docs and add usage scenario

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -37,7 +37,7 @@ Facilitar la creación y gestión de colas de atención remotas, reduciendo aglo
 ## Configuración y despliegue
 1. Clonar el repositorio y copiar `.env.example` a `.env`.
 2. Para el backend instalar Java y Maven, compilar con `mvn package` y ejecutar el jar.
-3. Para el frontend instalar Node.js 12, ejecutar `npm install` dentro de `simplQ-frontend/simplq` y luego `npm start`.
+3. Para el frontend instalar Node.js 18, ejecutar `npm install` dentro de `simplQ-frontend/simplq` y luego `npm start`.
 4. En entornos de producción se puede desplegar en servidores propios o en AWS siguiendo las guías de `docs/`.
 
 ## Métricas de éxito

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ java -jar target/simplq-1.0.0.jar
 
 ### Frontend
 
-1. Node.js 12.x instalado.
+1. Node.js 18.x instalado.
 
 ```bash
 cd simplQ-frontend/simplq

--- a/docs/INSTALACION_SERVIDOR.md
+++ b/docs/INSTALACION_SERVIDOR.md
@@ -72,8 +72,19 @@ npm install
 npm start
 ```
 
+El frontend requiere **Node.js 18** o superior instalado en el servidor.
+
 También puedes construir la imagen Docker disponible en `simplQ-frontend/simplq`:
 
 ```bash
 docker build -t simplq-frontend simplQ-frontend/simplq
 ```
+
+## Escenario de uso en el campus
+
+En un despliegue típico la aplicación se aloja en un servidor del data center. Las
+personas que atienden en el edificio de admisión acceden vía web para gestionar sus
+colas. Los clientes registran su llegada en un terminal ubicado en la entrada y en
+las paredes se muestran pantallas con el estado de las colas y el turno que sigue.
+La configuración de las colas (nombres, límites, etc.) se realiza previamente por el
+equipo de TI para que estén listas a diario.


### PR DESCRIPTION
## Summary
- align Node.js version in docs with frontend README
- clarify server installation doc with campus scenario and Node requirement

## Testing
- `mvn test` *(fails: Could not transfer artifact)*
- `CI=true npm test --silent` *(fails: Cannot find module '@testing-library/jest-dom/extend-expect')*

------
https://chatgpt.com/codex/tasks/task_e_688b72204ffc8326863132991b17b892